### PR TITLE
remove engine declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,5 @@
   "scripts": { "test": "NODE_PATH=./lib mocha --ui exports" },
   "devDependencies": {
     "mocha": "0.12.x"
-  },
-  "engines": { "node": "0.6.x" }
+  }
 }


### PR DESCRIPTION
this repo obviously works with engines newer then what was specified. This just results in an extra noisy warning

```js
npm WARN engine tmpl@1.0.3: wanted: {"node":"0.6.x"} (current: {"node":"1.6.2","npm":"2.7.3"})
```